### PR TITLE
Fix issue where customusebackground isn't honored if defaults are used

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -257,7 +257,7 @@ function navbutton_get_icon($buttonstype, $default, $context, $iconid, $bgcolour
         $files = $fs->get_area_files($context->id, 'block_navbuttons', 'icons', $iconid, '', false);
 
         if (empty($files)) {
-            return array($defaulturl, $bgcolour);
+            return array($defaulturl, $customusebackground ? $bgcolour : false);
         }
 
         $file = reset($files);


### PR DESCRIPTION
If we have a default set of icons in use, the default bgcolour is always used regardless of if customusebackground is true or not.  This simply updates function navbutton_get_icon() to check to see if it should return the bgcolour value or not when default images are in use.