### PR TITLE
Protection against non-existing property "hiddensections" in $COURSE

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -105,7 +105,7 @@ function draw_navbuttons() {
         if ($mod->sectionnum > 0 && $sectionnum != $mod->sectionnum) {
             $thissection = $sections[$mod->sectionnum];
 
-            if ($thissection->visible || !$COURSE->hiddensections ||
+            if ($thissection->visible || (property_exists($COURSE, "hiddensections") && !$COURSE->hiddensections) ||
                 has_capability('moodle/course:viewhiddensections', $context)
             ) {
                 $sectionnum = $mod->sectionnum;


### PR DESCRIPTION
Hi.
On my Moodle 3.0 instance, I get a warning about $COURSE->hiddensections not existing.
Here's a proposal to avoid this.
Thanks,
Mathias
